### PR TITLE
fix map and carousel position

### DIFF
--- a/src/components/SeekHelpCarousel/index.scss
+++ b/src/components/SeekHelpCarousel/index.scss
@@ -36,7 +36,7 @@
 .carousel {
   position: absolute;
   z-index: 1;
-  top: 26rem;
+  bottom: 12rem;
 }
 
 .slick-slide {

--- a/src/components/SeekHelpMap/index.scss
+++ b/src/components/SeekHelpMap/index.scss
@@ -1,8 +1,7 @@
 .mapStyle {
-  height: 70%;
+  height: 70vh;
   width: 100%;
   margin-top: 3rem;
-  position: absolute;
 }
 
 .marker {


### PR DESCRIPTION
Removed absolute position of map because it was rendering incorrectly in Search for Help page