### PR TITLE
changed link from jobs to opportunities

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -36,7 +36,7 @@ const App = () => (
         <Route exact path="/test">
           <ViolenceTestPage />
         </Route>
-        <Route exact path="/jobs">
+        <Route exact path="/opportunities">
           <JobsTrainingPage />
         </Route>
         <Route exact path="/about">


### PR DESCRIPTION
I named the link in App path="/jobs" but then I realized in Navbar it is "/opportunities" so I fixed the mistake. 