### PR TITLE
Fix help button responsiveness in main banner 

### DIFF
--- a/src/components/GenderViolenceMain/index.scss
+++ b/src/components/GenderViolenceMain/index.scss
@@ -48,7 +48,8 @@
   .main-container {
     .main-text {
       button {
-        width: 100%;
+        width: 25%;
+        margin-bottom: 1.5rem;
       }
     }
   }


### PR DESCRIPTION
it was:
<img width="248" alt="Screen Shot 2020-11-23 at 00 41 48" src="https://user-images.githubusercontent.com/67760504/99917950-d2953b00-2d24-11eb-9e1e-f9fec81dc05a.png">
it became:
<img width="519" alt="Screen Shot 2020-11-23 at 00 42 10" src="https://user-images.githubusercontent.com/67760504/99917959-dfb22a00-2d24-11eb-8462-f67dd99b8ec8.png">
